### PR TITLE
Integrate Supabase and Upstash caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,24 @@ The application expects game data with the following structure:
 
 ## 🔧 Configuration
 
-### Environment Variables (optional)
+### Environment Variables
 ```env
-PORT=3000                    # Server port
-NODE_ENV=development         # Environment mode
-CACHE_DURATION=300000        # Data cache duration (5 minutes)
+PORT=3000                                # Server port
+NODE_ENV=development                     # Environment mode
+
+# Supabase (provided automatically when using the Vercel extension)
+SUPABASE_URL=...                         # or NEXT_PUBLIC_SUPABASE_URL
+SUPABASE_ANON_KEY=...                    # or NEXT_PUBLIC_SUPABASE_ANON_KEY / service role key
+
+# Upstash Redis (provided automatically when using the Vercel extension)
+UPSTASH_REDIS_REST_URL=...
+UPSTASH_REDIS_REST_TOKEN=...
 ```
+
+When the Supabase credentials are supplied, game data is fetched directly from the configured tables
+(`ncaaf_games` and `nfl_games`). If no rows are returned—or Supabase is not configured—the server falls
+back to local JSON files and, ultimately, to generated demo data. Upstash Redis powers the shared cache
+for API responses; if its credentials are absent, the server degrades gracefully to in-memory caching.
 
 ### Data File Locations
 - JSON data: `data/ncaaf-games.json`
@@ -143,7 +155,7 @@ CACHE_DURATION=300000        # Data cache duration (5 minutes)
 
 ## 📈 Performance Optimizations
 
-- **In-memory caching** for game data (5-minute refresh)
+- **Upstash Redis caching** with automatic in-memory fallback (5-minute refresh)
 - **Lazy loading** for large datasets  
 - **Efficient filtering** algorithms for real-time updates
 - **Chart reuse** to minimize memory usage

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const fs = require('fs');
 const path = require('path');
+const { createClient } = require('@supabase/supabase-js');
 const app = express();
 const PORT = process.env.PORT || 3000;
 
@@ -10,8 +11,85 @@ app.use(cors());
 app.use(express.json());
 app.use(express.static('public')); // Serve your HTML files from 'public' folder
 
-// In-memory cache for games data
-const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+// Cache configuration (shared Redis via Upstash + local fallback)
+const CACHE_DURATION_SECONDS = 5 * 60; // 5 minutes
+const upstashUrl = process.env.UPSTASH_REDIS_REST_URL;
+const upstashToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.SUPABASE_ANON_KEY ||
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+const hasUpstash = Boolean(upstashUrl && upstashToken);
+const hasSupabase = Boolean(supabaseUrl && supabaseKey);
+
+if (!hasUpstash) {
+  console.warn('⚠️  Upstash Redis environment variables not configured. Falling back to in-memory caching.');
+}
+
+let supabaseClient = null;
+
+if (hasSupabase) {
+  supabaseClient = createClient(supabaseUrl, supabaseKey, {
+    auth: {
+      persistSession: false
+    }
+  });
+} else {
+  console.warn('⚠️  Supabase environment variables not configured. Falling back to JSON/demo data.');
+}
+
+async function executeUpstashCommand(...args) {
+  if (!hasUpstash) return null;
+
+  const response = await fetch(upstashUrl, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${upstashToken}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(args)
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Upstash request failed (${response.status}): ${body}`);
+  }
+
+  const result = await response.json();
+
+  if (result.error) {
+    throw new Error(`Upstash error: ${result.error}`);
+  }
+
+  return result.result;
+}
+
+async function readCache(key) {
+  try {
+    const result = await executeUpstashCommand('GET', key);
+    if (typeof result === 'string') {
+      return JSON.parse(result);
+    }
+    return null;
+  } catch (error) {
+    console.error(`⚠️  Unable to read cache for key ${key}:`, error.message);
+    return null;
+  }
+}
+
+async function writeCache(key, value) {
+  try {
+    await executeUpstashCommand('SET', key, JSON.stringify(value), 'EX', CACHE_DURATION_SECONDS);
+  } catch (error) {
+    console.error(`⚠️  Unable to write cache for key ${key}:`, error.message);
+  }
+}
+
+// In-memory cache for games data (fallback when Upstash is unavailable)
+const CACHE_DURATION = CACHE_DURATION_SECONDS * 1000;
 
 const DEFAULT_SPORT = 'ncaaf';
 
@@ -20,19 +98,50 @@ const SPORT_CONFIG = {
     label: 'NCAAF',
     dataFile: path.join(__dirname, 'data/ncaaf-games.json'),
     mapper: mapNCAAFGame,
-    demo: generateNCAAFDemoData
+    demo: generateNCAAFDemoData,
+    supabaseTable: 'ncaaf_games'
   },
   nfl: {
     label: 'NFL',
     dataFile: path.join(__dirname, 'data/nfl-games.json'),
     mapper: mapNFLGame,
-    demo: generateNFLDemoData
+    demo: generateNFLDemoData,
+    supabaseTable: 'nfl_games'
   }
 };
 
 const gameCaches = Object.fromEntries(
   Object.keys(SPORT_CONFIG).map(sport => [sport, { data: null, timestamp: null }])
 );
+
+async function getCachedGames(sport) {
+  const cacheKey = `games:${sport}`;
+
+  if (hasUpstash) {
+    const cached = await readCache(cacheKey);
+    if (Array.isArray(cached) && cached.length > 0) {
+      console.log(`📦 Serving ${SPORT_CONFIG[sport].label} games from Upstash cache`);
+      return cached;
+    }
+  }
+
+  const memoryCache = gameCaches[sport];
+  if (memoryCache.data && Date.now() - memoryCache.timestamp < CACHE_DURATION) {
+    console.log(`📦 Serving ${SPORT_CONFIG[sport].label} games from in-memory cache`);
+    return memoryCache.data;
+  }
+
+  return null;
+}
+
+async function setCachedGames(sport, games) {
+  const cacheKey = `games:${sport}`;
+  gameCaches[sport] = { data: games, timestamp: Date.now() };
+
+  if (hasUpstash) {
+    await writeCache(cacheKey, games);
+  }
+}
 
 const NFL_DIVISIONS = {
   'Arizona Cardinals': 'NFC West',
@@ -73,12 +182,27 @@ const NFL_DIVISIONS = {
 async function loadGamesForSport(requestedSport) {
   const sport = resolveSportKey(requestedSport);
   const config = SPORT_CONFIG[sport];
-  const { dataFile, mapper, demo, label } = config;
+  const { dataFile, mapper, demo, label, supabaseTable } = config;
+
+  const cachedGames = await getCachedGames(sport);
+  if (cachedGames) {
+    return cachedGames;
+  }
+
+  if (supabaseClient && supabaseTable) {
+    const supabaseGames = await loadGamesFromSupabase(supabaseTable, mapper, label);
+    if (Array.isArray(supabaseGames) && supabaseGames.length > 0) {
+      await setCachedGames(sport, supabaseGames);
+      return supabaseGames;
+    }
+  }
 
   try {
     if (!fs.existsSync(dataFile)) {
       console.log(`[${label}] JSON file not found, using demo data...`);
-      return demo();
+      const demoGames = demo();
+      await setCachedGames(sport, demoGames);
+      return demoGames;
     }
 
     console.log(`📂 Reading ${label} JSON file...`);
@@ -88,11 +212,47 @@ async function loadGamesForSport(requestedSport) {
 
     const games = rawGames.map(mapper).filter(Boolean);
     console.log(`✅ Loaded ${games.length} ${label} games from JSON file`);
+    await setCachedGames(sport, games);
     return games;
   } catch (error) {
     console.error(`❌ Error reading ${label} JSON:`, error.message);
     console.log(`🔄 Falling back to ${label} demo data`);
-    return demo();
+    const demoGames = demo();
+    await setCachedGames(sport, demoGames);
+    return demoGames;
+  }
+}
+
+async function loadGamesFromSupabase(table, mapper, label) {
+  if (!supabaseClient) return null;
+
+  try {
+    console.log(`☁️  Fetching ${label} games from Supabase table "${table}"...`);
+    const { data, error } = await supabaseClient
+      .from(table)
+      .select('*');
+
+    if (error) {
+      throw error;
+    }
+
+    if (!data || data.length === 0) {
+      console.warn(`⚠️  Supabase table "${table}" returned no rows.`);
+      return null;
+    }
+
+    const games = data.map(mapper).filter(Boolean);
+
+    if (games.length === 0) {
+      console.warn(`⚠️  Supabase data for table "${table}" did not produce any mapped games.`);
+      return null;
+    }
+
+    console.log(`✅ Loaded ${games.length} ${label} games from Supabase`);
+    return games;
+  } catch (error) {
+    console.error(`❌ Error loading ${label} games from Supabase:`, error.message);
+    return null;
   }
 }
 // Generate demo NCAAF data if JSON not available
@@ -373,20 +533,12 @@ function toBoolean(value) {
 // Get cached games or load fresh data
 async function getGamesData(requestedSport) {
   const sport = resolveSportKey(requestedSport);
-  const cache = gameCaches[sport];
-  const now = Date.now();
-
-  if (cache.data && cache.timestamp && (now - cache.timestamp) < CACHE_DURATION) {
-    return cache.data;
-  }
 
   try {
-    const games = await loadGamesForSport(sport);
-    cache.data = games;
-    cache.timestamp = now;
-    return games;
+    return await loadGamesForSport(sport);
   } catch (error) {
     console.error(`Error loading ${sport} games data:`, error);
+    const cache = gameCaches[sport];
     return cache.data || [];
   }
 }


### PR DESCRIPTION
## Summary
- initialize a Supabase client and connect to Upstash Redis via the REST API with automatic fallbacks
- hydrate game data from Supabase tables before falling back to JSON files or generated demo content
- document the required Supabase and Upstash environment variables along with the new caching strategy

## Testing
- node --check server.js

------
https://chatgpt.com/codex/tasks/task_e_68d579eb1c7c8326baf547fbeb1e13c5